### PR TITLE
Fix canvas scaling

### DIFF
--- a/src/Canvas.jsx
+++ b/src/Canvas.jsx
@@ -36,10 +36,11 @@ function Canvas({ details }) {
     img.onload = () => {
       canvas.width = canvas.offsetWidth * scale;
       canvas.height = canvas.offsetHeight * scale;
-      canvas.style.width = canvas.offsetWidth + "px";
-      canvas.style.height = canvas.offsetHeight + "px";
+      canvas.style.width = `${canvas.offsetWidth}px`;
+      canvas.style.height = `${canvas.offsetHeight}px`;
 
-      ctx.scale(scale, scale);
+      ctx.setTransform(scale, 0, 0, scale, 0, 0);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
       ctx.drawImage(img, 0, 0, canvas.offsetWidth, canvas.offsetHeight);
     };
   }, [index]);


### PR DESCRIPTION
## Summary
- clear canvas before drawing and reset transform to avoid runaway scaling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687132bcd9088321b620f4f2d2ecfe29