### PR TITLE
Add simple navigation pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,143 +1,59 @@
+import { useState } from "react";
+import Home from "./pages/Home";
+import WhatWeDo from "./pages/WhatWeDo";
+import WhoWeAre from "./pages/WhoWeAre";
+import HowWeGiveBack from "./pages/HowWeGiveBack";
+import TalkToUs from "./pages/TalkToUs";
 import "./index.css";
-import Canvas from "./Canvas";
-import data from "./data";
-import LocomotiveScroll from "locomotive-scroll";
-import { useEffect, useState, useRef } from "react";
-import gsap from "gsap";
 
 function App() {
-  const [showCanvas, setShowCanvas] = useState(false);
-  const headingref = useRef(null);
-  const growingSpan = useRef(null);
+  const [page, setPage] = useState("home");
 
-  useEffect(() => {
-    const scroll = new LocomotiveScroll();
-    return () => scroll.destroy();
-  }, []);
+  const renderPage = () => {
+    switch (page) {
+      case "whatwedo":
+        return <WhatWeDo />;
+      case "whoweare":
+        return <WhoWeAre />;
+      case "giveback":
+        return <HowWeGiveBack />;
+      case "talktous":
+        return <TalkToUs />;
+      default:
+        return <Home />;
+    }
+  };
 
-  useEffect(() => {
-    const handleClick = (e) => {
-      setShowCanvas((prevShowCanvas) => {
-        if (!prevShowCanvas) {
-          gsap.set(growingSpan.current, {
-            top: e.clientY,
-            left: e.clientX,
-          });
-
-          gsap.to("body", {
-            color: "#000",
-            backgroundColor: "#fd2c2a",
-            duration: 1.2,
-            ease: "power2.inOut",
-          });
-
-          gsap.to(growingSpan.current, {
-            scale: 1000,
-            duration: 2,
-            ease: "power2.inOut",
-            onComplete: () => {
-              gsap.set(growingSpan.current, {
-                scale: 0,
-                clearProps: "all",
-              });
-            },
-          });
-        } else {
-          gsap.to("body", {
-            color: "#fff",
-            backgroundColor: "#000",
-            duration: 1.2,
-            ease: "power2.inOut",
-          });
-        }
-
-        return !prevShowCanvas;
-      });
-    };
-
-    const headingElement = headingref.current;
-    headingElement.addEventListener("click", handleClick);
-
-    // Clean up event listener on unmount
-    return () => headingElement.removeEventListener("click", handleClick);
-  }, []);
+  const links = [
+    { label: "What we do", key: "whatwedo" },
+    { label: "Who we are", key: "whoweare" },
+    { label: "How we give back", key: "giveback" },
+    { label: "Talk to us", key: "talktous" },
+  ];
 
   return (
-    <>
-      <span
-        ref={growingSpan}
-        className="growing rounded-full block fixed top-[-20px] left-[-20px] w-5 h-5"
-      ></span>
-      <div className="w-full relative min-h-screen font-['Helvetica_Now_Display']">
-        {showCanvas &&
-          data[0].map((canvasdets, index) => (
-            <Canvas key={index} details={canvasdets} />
-          ))}
-        <div className="w-full relative z-[1] h-screen  ">
-          <nav className="w-full p-8 flex justify-between z-50 border-b border-white/10 ">
-            <div className="brand text-2xl font-md">Thirtysixstudio</div>
-            <div className="links flex gap-10">
-              {[
-                "What we do",
-                "Who we are",
-                "How we give back",
-                "Talk to us",
-              ].map((link, index) => (
-                <a
-                  key={index}
-                  href={`#${link.toLowerCase()}`}
-                  className="text-md hover:text-gray-300"
-                >
-                  {link}
-                </a>
-              ))}
-            </div>
-          </nav>
-          <div className="textcontainer  w-full px-[20%]">
-            <div className="text w-[50%]">
-              <h3 className="text-4xl leading-[1.2] mt-10">
-                At Thirtysixstudio, we build immersive digital experiences for
-                brands with a purpose.
-              </h3>
-              <p className="text-lg w-[80%] mt-10 font-normal">
-                We are a team of designers, developers, and strategists who are
-                passionate about creating digital experiences that are both
-                beautiful and functional.
-              </p>
-              <p className="text-md mt-10">Please click on ThirtySixStudio Text Below...</p>
-            </div>
-          </div>
-          <div className="w-full absolute bottom-0 left-0">
-            <h1
-              ref={headingref}
-              className="text-[17rem] font-normal tracking-tight leading-none pl-5"
-            >
-              Thirtysixstudios
-            </h1>
-          </div>
+    <div className="w-full min-h-screen font-['Helvetica_Now_Display']">
+      <nav className="w-full p-8 flex justify-between z-50 border-b border-white/10">
+        <div
+          className="brand text-2xl font-md cursor-pointer"
+          onClick={() => setPage("home")}
+        >
+          Thirtysixstudio
         </div>
-      </div>
-      <div className="w-full relative h-screen  mt-32 px-10">
-        {showCanvas &&
-          data[1].map((canvasdets, index) => (
-            <Canvas key={index} details={canvasdets} />
+        <div className="links flex gap-10">
+          {links.map((link) => (
+            <button
+              key={link.key}
+              onClick={() => setPage(link.key)}
+              className="text-md hover:text-gray-300 capitalize"
+            >
+              {link.label}
+            </button>
           ))}
-        <h1 className="text-8xl tracking-tighter">about the brand</h1>
-        <p className="text-4xl leading-[1.8] w-[80%] mt-10 font-light">
-          we are a team of designers, developers, and strategists who are
-          passionate about creating digital experiences that are both beautiful
-          and functional, we are a team of designers, developers, and
-          strategists who are passionate about creating digital experiences that
-          are both beautiful and functional.
-        </p>
-
-        <img
-          className="w-[80%] mt-10"
-          src="https://directus.funkhaus.io/assets/b3b5697d-95a0-4af5-ba59-b1d423411b1c?withoutEnlargement=true&fit=outside&width=1400&height=1400"
-          alt=""
-        />
-      </div>
-    </>
+        </div>
+      </nav>
+      {renderPage()}
+    </div>
   );
 }
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,114 @@
+import "../index.css";
+import Canvas from "../Canvas";
+import data from "../data";
+import LocomotiveScroll from "locomotive-scroll";
+import { useEffect, useState, useRef } from "react";
+import gsap from "gsap";
+
+function Home() {
+  const [showCanvas, setShowCanvas] = useState(false);
+  const headingref = useRef(null);
+  const growingSpan = useRef(null);
+
+  useEffect(() => {
+    const scroll = new LocomotiveScroll();
+    return () => scroll.destroy();
+  }, []);
+
+  useEffect(() => {
+    const handleClick = (e) => {
+      setShowCanvas((prevShowCanvas) => {
+        if (!prevShowCanvas) {
+          gsap.set(growingSpan.current, {
+            top: e.clientY,
+            left: e.clientX,
+          });
+          gsap.to("body", {
+            color: "#000",
+            backgroundColor: "#fd2c2a",
+            duration: 1.2,
+            ease: "power2.inOut",
+          });
+          gsap.to(growingSpan.current, {
+            scale: 1000,
+            duration: 2,
+            ease: "power2.inOut",
+            onComplete: () => {
+              gsap.set(growingSpan.current, {
+                scale: 0,
+                clearProps: "all",
+              });
+            },
+          });
+        } else {
+          gsap.to("body", {
+            color: "#fff",
+            backgroundColor: "#000",
+            duration: 1.2,
+            ease: "power2.inOut",
+          });
+        }
+        return !prevShowCanvas;
+      });
+    };
+
+    const headingElement = headingref.current;
+    headingElement.addEventListener("click", handleClick);
+    return () => headingElement.removeEventListener("click", handleClick);
+  }, []);
+
+  return (
+    <>
+      <span
+        ref={growingSpan}
+        className="growing rounded-full block fixed top-[-20px] left-[-20px] w-5 h-5"
+      ></span>
+      <div className="w-full relative min-h-screen font-['Helvetica_Now_Display']">
+        {showCanvas &&
+          data[0].map((canvasdets, index) => (
+            <Canvas key={index} details={canvasdets} />
+          ))}
+        <div className="w-full relative z-[1] h-screen">
+          <div className="textcontainer  w-full px-[20%]">
+            <div className="text w-[50%]">
+              <h3 className="text-4xl leading-[1.2] mt-10">
+                At Thirtysixstudio, we build immersive digital experiences for brands with a purpose.
+              </h3>
+              <p className="text-lg w-[80%] mt-10 font-normal">
+                We are a team of designers, developers, and strategists who are passionate about creating digital experiences that are both beautiful and functional.
+              </p>
+              <p className="text-md mt-10">Please click on ThirtySixStudio Text Below...</p>
+            </div>
+          </div>
+          <div className="w-full absolute bottom-0 left-0">
+            <h1 ref={headingref} className="text-[17rem] font-normal tracking-tight leading-none pl-5">
+              Thirtysixstudios
+            </h1>
+          </div>
+        </div>
+      </div>
+      <div className="w-full relative h-screen mt-32 px-10">
+        {showCanvas &&
+          data[1].map((canvasdets, index) => (
+            <Canvas key={index} details={canvasdets} />
+          ))}
+        <h1 className="text-8xl tracking-tighter">about the brand</h1>
+        <p className="text-4xl leading-[1.8] w-[80%] mt-10 font-light">
+          we are a team of designers, developers, and strategists who are passionate about creating digital experiences that are both beautiful and functional.
+        </p>
+        <img
+          className="w-[80%] mt-10"
+          src="https://directus.funkhaus.io/assets/b3b5697d-95a0-4af5-ba59-b1d423411b1c?withoutEnlargement=true&fit=outside&width=1400&height=1400"
+          alt="About"
+        />
+      </div>
+      <div className="w-full relative py-20 px-10 bg-gray-900">
+        <h2 className="text-6xl mb-6">Our Mission</h2>
+        <p className="text-lg w-[80%] mb-10">We help brands tell their story through outstanding design and technology. Our goal is to deliver meaningful experiences that resonate.</p>
+        <img className="w-[80%]" src="https://source.unsplash.com/featured/800x400?design" alt="mission" />
+      </div>
+    </>
+  );
+}
+
+export default Home;

--- a/src/pages/HowWeGiveBack.jsx
+++ b/src/pages/HowWeGiveBack.jsx
@@ -1,0 +1,13 @@
+function HowWeGiveBack() {
+  return (
+    <div className="px-10 py-16">
+      <h1 className="text-6xl mb-6">How We Give Back</h1>
+      <p className="text-lg mb-4 w-[80%]">
+        Our team believes in supporting the community through open-source contributions and mentorship.
+      </p>
+      <img className="w-[80%]" src="https://source.unsplash.com/featured/800x400?community" alt="Giving Back" />
+    </div>
+  );
+}
+
+export default HowWeGiveBack;

--- a/src/pages/TalkToUs.jsx
+++ b/src/pages/TalkToUs.jsx
@@ -1,0 +1,13 @@
+function TalkToUs() {
+  return (
+    <div className="px-10 py-16">
+      <h1 className="text-6xl mb-6">Talk To Us</h1>
+      <p className="text-lg mb-4 w-[80%]">
+        Ready to start your next project? Reach out and let's chat about your ideas.
+      </p>
+      <img className="w-[80%]" src="https://source.unsplash.com/featured/800x400?contact" alt="Contact" />
+    </div>
+  );
+}
+
+export default TalkToUs;

--- a/src/pages/WhatWeDo.jsx
+++ b/src/pages/WhatWeDo.jsx
@@ -1,0 +1,13 @@
+function WhatWeDo() {
+  return (
+    <div className="px-10 py-16">
+      <h1 className="text-6xl mb-6">What We Do</h1>
+      <p className="text-lg mb-4 w-[80%]">
+        We create websites, applications and digital products that help brands grow.
+      </p>
+      <img className="w-[80%]" src="https://source.unsplash.com/featured/800x400?workspace" alt="What We Do" />
+    </div>
+  );
+}
+
+export default WhatWeDo;

--- a/src/pages/WhoWeAre.jsx
+++ b/src/pages/WhoWeAre.jsx
@@ -1,0 +1,13 @@
+function WhoWeAre() {
+  return (
+    <div className="px-10 py-16">
+      <h1 className="text-6xl mb-6">Who We Are</h1>
+      <p className="text-lg mb-4 w-[80%]">
+        We are a passionate team of designers and developers dedicated to crafting engaging digital experiences.
+      </p>
+      <img className="w-[80%]" src="https://source.unsplash.com/featured/800x400?team" alt="Who We Are" />
+    </div>
+  );
+}
+
+export default WhoWeAre;


### PR DESCRIPTION
## Summary
- create `pages` directory with basic placeholders
- add Home page component with extra mission section and images
- simplify `App` to render new page components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871359683188321aba5a8b460b02cff